### PR TITLE
feat: set client session info for hana-client

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,17 @@ A dictionary with following properties:
 - `userName`: user name.
 - `password`: password.
 
+##### Session variables
+
+For `@sap/hana-client`, it's possible to provide client session variables along with the connection properties when establishing a connection. The session variables must be provided as a key-value pair object with the property name `sessionVariables` (see example below). This property is <i>optional</i>.
+
+```js
+sessionVariables: {
+    application: "myApplication",
+    applicationUser: "user"
+}
+```
+
 #### options
 
 An <i>optional</i> dictionary with the any of the following properties:

--- a/lib/Utils.js
+++ b/lib/Utils.js
@@ -19,6 +19,42 @@ const DEFAULT_POOL_OPTIONS = {
 };
 
 /**
+ * Sets client session information which is a list of session variables defined
+ * as key-value pairs (case sensitive). Invalid session variables are ignored.
+ *
+ * @param {object} sessionInfo Client session info object
+ * @returns An object with constructed session variables, or an empty object
+ *
+ * @remark
+ * This applies to SAP HANA Client only.
+ * It's important to set session variables when establishing a connection.
+ *
+ * @see List of predefined session variables
+ * {@link https://help.sap.com/viewer/4fe29514fd584807ac9f2a04f6754767/2.0.03/en-US/20fd82b675191014b22c8af08d0b319c.html}
+ * @see SAP HANA Client Interface Programming Reference
+ * {@link https://help.sap.com/viewer/1efad1691c1f496b8b580064a6536c2d/Cloud/en-US/4fe9978ebac44f35b9369ef5a4a26f4c.html}
+ */
+const setSessionVariables = (sessionInfo) => {
+  const sessionVariables = {};
+
+  if (Object.prototype.toString.call(sessionInfo) !== '[object Object]') {
+    // log only
+    Utils.emitMessage(EventType.CONNECTION_CREATE_ERROR,
+      'Client session info will be ignored. It must be a valid key-value pair ' +
+      'object, e.g. { "application": "myApplication" }');
+  } else {
+    // compose each key with "sessionVariable" which is then the property key
+    // of the session variable, e.g. "sessionVariable:APPLCIATION"
+    for (const [k, v] of Object.entries(sessionInfo)) {
+      // key is case sensitive
+      sessionVariables[`sessionVariable:${k.toUpperCase()}`] = v;
+    }
+  }
+
+  return sessionVariables;
+};
+
+/**
  * @class
  * @private
  */
@@ -65,6 +101,18 @@ class Utils {
 
     const hostName = params.hostName ? params.hostName : params.serverNode ? params.serverNode.split(":")[0] : undefined;
     const port = params.port ? params.port : params.serverNode ? params.serverNode.split(":")[1] : undefined;
+
+    // include session variables for hana client if specified
+    if (params.sessionVariables) {
+      if (isHANAClient) {
+        const sessionVariables = setSessionVariables(params.sessionVariables);
+        // assign to the connection properties
+        params = Object.assign(params, sessionVariables);
+      }
+      // exclude the original sessionVariables object from connection properties
+      // no handling for node-hdb
+      delete params.sessionVariables;
+    }
 
     return isHANAClient ? {
       HOST: hostName,

--- a/test/Utils.js
+++ b/test/Utils.js
@@ -193,6 +193,60 @@ describe('Utils', function () {
       should(dbParams.UID).exactly(params.userName);
       should(dbParams.PWD).exactly(params.password);
     });
+    it('should set client session variables if the driver is HANA client', function () {
+      const params = {
+        hostName: 'test1',
+        port: '30015',
+        userName: 'tester',
+        password: 'testPWD',
+        sessionVariables: {
+          application: 'myApplication',
+          foo: 'bar'
+        }
+      };
+
+      const dbParams = Utils.getPoolParams(params);
+      should(dbParams.HOST).exactly(params.hostName);
+      should(dbParams.PORT).exactly(params.port);
+      should(dbParams.UID).exactly(params.userName);
+      should(dbParams.PWD).exactly(params.password);
+      dbParams.should.have.property('sessionVariable:APPLICATION', 'myApplication');
+      dbParams.should.have.property('sessionVariable:FOO', 'bar');
+    });
+    it('should NOT set invalid client session variables if the driver is HANA client', function () {
+      const params = {
+        hostName: 'test1',
+        port: '30015',
+        userName: 'tester',
+        password: 'testPWD',
+        sessionVariables: 'foo:bar'
+      };
+
+      const dbParams = Utils.getPoolParams(params);
+      should(dbParams.HOST).exactly(params.hostName);
+      should(dbParams.PORT).exactly(params.port);
+      should(dbParams.UID).exactly(params.userName);
+      should(dbParams.PWD).exactly(params.password);
+      dbParams.should.not.have.property('sessionVariable:FOO');
+    });
+    it('should NOT set client session variables if the driver is node-hdb', function () {
+      const params = {
+        hostName: 'test1',
+        port: '30015',
+        userName: 'tester',
+        password: 'testPWD',
+        sessionVariables: {
+          foo: 'bar'
+        }
+      };
+
+      const dbParams = Utils.getPoolParams(params, false);
+      should(dbParams.host).exactly(params.hostName);
+      should(dbParams.port).exactly(params.port);
+      should(dbParams.user).exactly(params.userName);
+      should(dbParams.password).exactly(params.password);
+      dbParams.should.not.have.property('sessionVariable:FOO');
+    });
     it('should return the parameters for HANA get connection if the driver is node-hdb', function () {
       const params = {
         hostName: 'test1',


### PR DESCRIPTION
Adds the possibility to provide client session info along other connection properties when establishing a connection.